### PR TITLE
fix/docker

### DIFF
--- a/.github/workflows/auto-container.yml
+++ b/.github/workflows/auto-container.yml
@@ -1,9 +1,10 @@
-name: Publish Docker
+name: Publish Container
 
 on:
   push:
     tags:
       - "*"
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ssh-key: "${{ secrets.COMMIT_KEY }}" # To avoid not triggering the auto-container
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
- fix: docker builder
- fix: use deploykey instead of gh actions creds for push

## Changes

*please link the issues here*

Changes proposed in this pull request
