### PR TITLE
Add basic auth example

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Run with a configuration file:
 
 ### Run it locally for dev
 
-You can just leveraging the Docker image
+You can just leverage the Docker image:
 
 ```
 docker run -p 10025:10025 -v `pwd`/emails:/smtp-relay/received_emails loopingz/smtp-relay:latest ./configs/fake-smtp.jsonc
@@ -212,6 +212,116 @@ A `format` can be defined too
 
 By default the loggers are defined as a single `CONSOLE` logger. You can disable completely by adding a `loggers: []` property
 
+## Basic Auth
+
+To enable basic auth for the smtp relay you need to set the static-auth filter, add the AND filters operator, set the authMethods and ensure secure is set to true as in the config example below.
+
+Set the SMTP_USERNAME, SMTP_PASSWORD as env variables. 
+Note that the password will need to be passed in with the below "plain:" prepended to your password. 
+I set them like this in the Dockerfile. Later you can set them in your helmfile if your using k8s.
+
+Dockerfile example:
+```
+ENV SMTP_USERNAME: yourusername
+ENV SMTP_PASSWORD: plain:yourpassword
+```
+
+Helmfile example:
+
+```
+env: 
+  - name: SMTP_USERNAME
+    value: "username"
+  - name: SMTP_PASSWORD
+    value: "sha256:yourpassword"
+```
+
+For manual testing you will need to pass the username and password to the smtp-relay base64 encoded. If you use the SMTP auth method LOGIN you will encode and pass in the username and password seperately.
+
+Example smtp test:
+
+1. Port forward your container to your localhost.
+
+```
+ docker run -p 10025:10025 loopingz/smtp-relay:latest
+ ```
+
+
+2. Connect to smtp-relay
+```
+openssl s_client -connect localhost:10025
+```
+```
+S: 220 smtp.server.com Simple Mail Transfer Service Ready
+C: EHLO client.example.com
+S: 250-smtp.server.com Hello client.example.com
+S: 250-SIZE 1000000
+S: 250 AUTH LOGIN PLAIN CRAM-MD5
+C: AUTH LOGIN
+S: 334 VXNlcm5hbWU6
+C: adlxdkej
+S: 334 UGFzc3dvcmQ6
+C: lkujsefxlj
+S: 235 2.7.0 Authentication successful
+```
+
+
+Examples of ways to base64 encode:
+Encode your credentials:
+
+```
+base64 <<< password
+```
+
+Gotcha: make sure to use a base64 encoder that encodes with Destination character set utf8 and Destination new line seperator LF(Unix), this online one does that, the MAC cml one is poop
+https://www.base64encode.org/
+
+Example Schema used to add basic auth to an aws-ses smtp-relay running in k8s:
+
+```
+{
+  "$schema": "https://raw.githubusercontent.com/loopingz/smtp-relay/main/config.schema.json",
+  "flows": {
+    "localhost": {
+      "filters": [
+        {
+          "type": "whitelist",
+          "ips": [
+            "regexp:.*"
+          ]
+        },
+        {
+          "type": "static-auth"
+        }
+      ],
+      "filtersOperator": "AND",
+      "outputs": [
+        {
+          "type": "aws",
+          "ses": {}
+        }
+      ]
+    }
+  },
+  "cachePath": "/tmp/.email_${iso8601}.eml",
+  "options": {
+    "authMethods": [
+      "PLAIN",
+      "LOGIN"
+    ],
+    "secure": true,
+    "disableReverseLookup": true,
+    "authOptional": true,
+    "loggers": [
+      {
+        "level": "INFO",
+        "type": "CONSOLE"
+      }
+    ]
+  }
+}
+```
+Note: Change your loggers level to DEBUG for help troubleshooting.
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):

--- a/README.md
+++ b/README.md
@@ -266,8 +266,7 @@ S: 235 2.7.0 Authentication successful
 ```
 
 
-Examples of ways to base64 encode:
-Encode your credentials:
+Examples of ways to base64 encode your credentials:
 
 ```
 base64 <<< password


### PR DESCRIPTION
## Changes

Update the readme with an example of a basic auth implementation for the aws-smtp-relay.
