### PR TITLE
fix: use async unlink with a log for error

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,6 +2,8 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    
 permissions:
   contents: write
   pull-requests: write

--- a/src/server.ts
+++ b/src/server.ts
@@ -370,12 +370,13 @@ export class SmtpServer {
       session.email = await simpleParser(fs.createReadStream(session.emailPath));
       await this.onDataRead(session);
       if (!this.config.keepCache) {
-        fs.unlinkSync(session.emailPath);
+        fs.unlink(session.emailPath, (err) => {
+          err && this.logger.log("ERROR", `Unable to delete ${session.emailPath}`, err);
+        });
       }
       callback();
     });
 
-    /* istanbul ignore next */
     stream.on("error", err => callback(`error converting stream - ${err}`));
   }
 


### PR DESCRIPTION
Close #67

## Changes

Use async unlink for cache with an error handling
