### PR TITLE
docs: Add documentation for the dkim-generate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ docker run -p 10025:10025 loopingz/smtp-relay:latest configs/aws-smtp-relay.json
 }
 ```
 
-[!NOTE]
-Replace `main` in the URL with a tag version to get the configuration format of a specific version.
+> [!NOTE]
+> Replace `main` in the URL with a tag version to get the configuration format of a specific version.
 
 **Run with a configuration file:**
 ```jsonc
@@ -173,82 +173,7 @@ Example Configuration:
     *   `maxResolveCount`: (number, optional) DNS lookup limit for SPF. RFC7208 requires this limit to be 10. Defaults to `10`.
     *   `maxVoidCount`: (number, optional) DNS lookup limit for SPF that produce an empty result. RFC7208 requires this limit to be 2. Defaults to `2`.
 *   `enforceDmarc`: (string, optional) Enforce a specific DMARC policy. If set, all `_dmarc` records are replaced with the policy specified here. For example, `"v=DMARC1; p=reject;"`.
-
-## DKIM Key Generation
-
-This utility command helps you generate a new DKIM (DomainKeys Identified Mail) RSA key pair. It will output the public key formatted as a DNS TXT record that you need to add to your domain's DNS settings, and the private key along with example configuration snippets for use with the Nodemailer processor in this SMTP relay.
-
-### Usage
-
-You can run the command using `npx` (even without installing the package globally):
-```bash
-npx smtp-relay dkim-generate <your-domain.com> <selector>
-```
-
--   `<your-domain.com>`: Replace this with the domain for which you are generating the DKIM key (e.g., `example.com`).
--   `<selector>`: Replace this with a DKIM selector. This is a name you choose, often `default` or a date (e.g., `jan2024`). It must be alphanumeric.
-
-For example:
-```bash
-npx smtp-relay dkim-generate example.com default
-```
-
-### Expected Output
-
-After running the command, you will see output similar to the following:
-
-1.  **DNS TXT Record:**
-    The command will print the DNS TXT record that you need to create for your domain. It will look something like this:
-    ```text
-    <selector>._domainkey.<your-domain.com>    v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA...your...public...key...data...AQAB
-    ```
-    -   Replace `<selector>` and `<your-domain.com>` with the actual values you used.
-    -   The long string starting with `p=` is your public key. Ensure you copy the entire value for your DNS record.
-
-2.  **Configuration Snippets for `smtp-relay`:**
-    The command will also provide JSON snippets that you can adapt for your `smtp-relay` configuration, specifically for use with the `nodemailer` processor. This allows `smtp-relay` to sign outgoing emails using the generated private key.
-
-    **Option 1: Single DKIM key configuration**
-    If you are configuring a single DKIM key directly in your `nodemailer` processor options:
-    ```json
-    {
-      "outputs": [
-        {
-          "type": "nodemailer",
-          "dkim": {
-            "domainName": "<your-domain.com>",
-            "keySelector": "<selector>",
-            "privateKey": "-----BEGIN PRIVATE KEY-----\n...your...private...key...data...\n-----END PRIVATE KEY-----\n"
-          }
-          // ... other nodemailer options
-        }
-      ]
-    }
-    ```
-
-    **Option 2: Multiple DKIM keys using the `dkims` object**
-    If you prefer to manage multiple DKIM keys, potentially for different domains:
-    ```json
-    {
-      "outputs": [
-        {
-          "type": "nodemailer",
-          "dkims": {
-            "<your-domain.com>": {
-              "keySelector": "<selector>",
-              "privateKey": "-----BEGIN PRIVATE KEY-----\n...your...private...key...data...\n-----END PRIVATE KEY-----\n"
-            }
-            // ... potentially other domains
-          }
-          // ... other nodemailer options
-        }
-      ]
-    }
-    ```
-    **Important:**
-    - The `privateKey` value will be the actual multi-line PEM formatted private key. Ensure it is correctly formatted in your JSON configuration (e.g., with `\n` for newlines if storing as a single string, or loaded from a file/environment variable in production). The example output from the tool will show the private key directly.
-    - Store your private key securely. Do not commit it directly into your version control if your configuration file is tracked.
-
+   
 ### Processors
 
 These components receive the email sent after it was accepted by the filters.
@@ -309,8 +234,8 @@ The `FILE` type has a size limit defined and will increment a number at the end 
 A `format` can be defined too.
 
 By default, the loggers are defined as a single `CONSOLE` logger.
-[!NOTE]
-You can disable logging completely by adding a `loggers: []` property.
+> [!NOTE]
+> You can disable logging completely by adding a `loggers: []` property.
 
 ## CloudEvent
 
@@ -473,8 +398,8 @@ The password and username are passed either in the configuration with the fields
 The password is prefixed by `${hashAlgorithm}:` where `hashAlgorithm` is one of `plain`, `sha256`, `sha512`, or `md5`. You can get the full list of hash algorithms supported by Node with this command:
 `node -e "console.log(require('crypto').getHashes())"`
 
-[!WARNING]
-`plain` can be used to not hash the password, but it is not recommended for security reasons.
+> [!WARNING]
+> `plain` can be used to not hash the password, but it is not recommended for security reasons.
 
 A `salt` parameter can be added in the configuration with the `salt` field, or via the environment variable `SMTP_PASSWORD_SALT`.
 
@@ -519,8 +444,8 @@ For manual testing, you will need to pass the username and password to the SMTP 
 base64 <<< "password"
 ```
 
-[!IMPORTANT]
-Make sure to use a Base64 encoder that encodes with Destination character set UTF-8 and Destination new line separator LF (Unix). [This online one](https://www.base64encode.org/) does that. The macOS command-line `base64` tool might behave differently.
+> [!IMPORTANT]
+> Make sure to use a Base64 encoder that encodes with Destination character set UTF-8 and Destination new line separator LF (Unix). [This online one](https://www.base64encode.org/) does that. The macOS command-line `base64` tool might behave differently.
 
 **Example Schema for AWS SES with Basic Auth in K8s:**
 ```json
@@ -567,5 +492,82 @@ Make sure to use a Base64 encoder that encodes with Destination character set UT
 }
 ```
 
-[!NOTE]
-Change your logger level to `DEBUG` for help troubleshooting.
+> [!NOTE]
+> Change your logger level to `DEBUG` for help troubleshooting.
+
+
+## DKIM Key Generation
+
+This utility command helps you generate a new DKIM (DomainKeys Identified Mail) RSA key pair. It will output the public key formatted as a DNS TXT record that you need to add to your domain's DNS settings, and the private key along with example configuration snippets for use with the Nodemailer processor in this SMTP relay.
+
+### Usage
+
+You can run the command using `npx` (even without installing the package globally):
+```bash
+npx smtp-relay dkim-generate <your-domain.com> <selector>
+```
+
+-   `<your-domain.com>`: Replace this with the domain for which you are generating the DKIM key (e.g., `example.com`).
+-   `<selector>`: Replace this with a DKIM selector. This is a name you choose, often `default` or a date (e.g., `jan2024`). It must be alphanumeric.
+
+For example:
+```bash
+npx smtp-relay dkim-generate example.com default
+```
+
+### Expected Output
+
+After running the command, you will see output similar to the following:
+
+1.  **DNS TXT Record:**
+    The command will print the DNS TXT record that you need to create for your domain. It will look something like this:
+    ```text
+    <selector>._domainkey.<your-domain.com>    v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA...your...public...key...data...AQAB
+    ```
+    -   Replace `<selector>` and `<your-domain.com>` with the actual values you used.
+    -   The long string starting with `p=` is your public key. Ensure you copy the entire value for your DNS record.
+
+2.  **Configuration Snippets for `smtp-relay`:**
+    The command will also provide JSON snippets that you can adapt for your `smtp-relay` configuration, specifically for use with the `nodemailer` processor. This allows `smtp-relay` to sign outgoing emails using the generated private key.
+
+    **Option 1: Single DKIM key configuration**
+    If you are configuring a single DKIM key directly in your `nodemailer` processor options:
+    ```json
+    {
+      "outputs": [
+        {
+          "type": "nodemailer",
+          "dkim": {
+            "domainName": "<your-domain.com>",
+            "keySelector": "<selector>",
+            "privateKey": "-----BEGIN PRIVATE KEY-----\n...your...private...key...data...\n-----END PRIVATE KEY-----\n"
+          }
+          // ... other nodemailer options
+        }
+      ]
+    }
+    ```
+
+    **Option 2: Multiple DKIM keys using the `dkims` object**
+    If you prefer to manage multiple DKIM keys, potentially for different domains:
+    ```json
+    {
+      "outputs": [
+        {
+          "type": "nodemailer",
+          "dkims": {
+            "<your-domain.com>": {
+              "keySelector": "<selector>",
+              "privateKey": "-----BEGIN PRIVATE KEY-----\n...your...private...key...data...\n-----END PRIVATE KEY-----\n"
+            }
+            // ... potentially other domains
+          }
+          // ... other nodemailer options
+        }
+      ]
+    }
+    ```
+    **Important:**
+    - The `privateKey` value will be the actual multi-line PEM formatted private key. Ensure it is correctly formatted in your JSON configuration (e.g., with `\n` for newlines if storing as a single string, or loaded from a file/environment variable in production). The example output from the tool will show the private key directly.
+    - Store your private key securely. Do not commit it directly into your version control if your configuration file is tracked.
+

--- a/README.md
+++ b/README.md
@@ -14,35 +14,34 @@
 
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
-This project replace a previous project `aws-smtp-relay`
+> This project replaces a previous project: `aws-smtp-relay`.
 
-The goal is to have a dynamic SMTP server that can either be used to run a debug SMTP locally that just store received email in a folder
-Or relay a SMTP protocol to an SES API call (goal of `aws-smtp-relay`)
-Or simulate some Incoming capabilities of AWS SES, like `mail2s3` or `mail2sqs` and similar `mail2gcpstorage` and `mail2gcppubsub`
+The goal is to have a dynamic SMTP server that can either be:
+- Used to run a debug SMTP locally that just stores received email in a folder.
+- Used to relay SMTP protocol to an SES API call (original goal of `aws-smtp-relay`).
+- Used to simulate some Incoming capabilities of AWS SES, like `mail2s3` or `mail2sqs`, and similar `mail2gcpstorage` and `mail2gcppubsub`.
 
 ## Quick Start
 
-### Replace aws-smtp-relay
+### Replace `aws-smtp-relay`
 
-Docker command
-
-```
+**Docker command:**
+```bash
 docker run -p 10025:10025 loopingz/smtp-relay:latest configs/aws-smtp-relay.jsonc
 ```
 
-**Configuration file can leverage the published schema**
-
-```
+**Configuration file can leverage the published schema:**
+```json
 {
   "$schema": "https://raw.githubusercontent.com/loopingz/smtp-relay/main/config.schema.json"
 }
 ```
 
-Replace `main` in url by the tag version to get the configuration format of a specific version
+[!NOTE]
+Replace `main` in the URL with a tag version to get the configuration format of a specific version.
 
-Run with a configuration file:
-
-```
+**Run with a configuration file:**
+```jsonc
 // Replace my previous project aws-smtp-relay
 {
   "$schema": "https://raw.githubusercontent.com/loopingz/smtp-relay/main/config.schema.json",
@@ -56,9 +55,9 @@ Run with a configuration file:
         }
       ],
       "outputs": [
+        // Send it to SES
         {
           "type": "aws",
-          // Send it to SES
           "ses": {}
         }
       ]
@@ -84,8 +83,7 @@ Run with a configuration file:
 ```
 
 ### SMTP 2 GCP Storage
-
-```
+```jsonc
 {
   "flows": {
     "localhost": {
@@ -97,11 +95,11 @@ Run with a configuration file:
         }
       ],
       "outputs": [
+        // Store it in the bucket
         {
           "type": "gcp",
-          // Store it in the bucket
-          "path": "gs://myemail/",
           // Send a message to the queue containing the bucket url if exist and the metadata of the email
+          "path": "gs://myemail/",
           "pubsub": ""
         }
       ]
@@ -118,8 +116,7 @@ Run with a configuration file:
 ### Run it locally for dev
 
 You can just leverage the Docker image:
-
-```
+```bash
 docker run -p 10025:10025 -v `pwd`/emails:/smtp-relay/received_emails loopingz/smtp-relay:latest ./configs/fake-smtp-docker.jsonc
 # With auth
 docker run -e SMTP_USERNAME=test -e SMTP_PASSWORD=plain:test -p 10025:10025 -v `pwd`/emails:/smtp-relay/received-emails loopingz/smtp-relay:latest configs/fake-smtp-with-auth.jsonc
@@ -127,8 +124,7 @@ docker run -e SMTP_USERNAME=test -e SMTP_PASSWORD=plain:test -p 10025:10025 -v `
 
 ## Concepts
 
-The smtp server is subdivided with:
-
+The SMTP server is subdivided into the following components:
 - Filters
 - Core
 - Processors
@@ -136,63 +132,162 @@ The smtp server is subdivided with:
 
 ### Filters
 
-These components decide to accept or refuse an email.
+These components decide to accept or refuse an email. At each SMTP command step, they can make a decision to refuse or accept an email, or not make a decision (`boolean|undefined`).
 
-At each SMTP command step, they can make a decision to refuse or accept an email or not make a decision `boolean|undefined`
+By default, the following filters exist:
+- `whitelist`: allow emails based on regexp or exact values.
+- `http-auth`: proxy the authentication to an HTTP endpoint.
+- `http-filter`: proxy the decision on the email to an HTTP endpoint.
+- `static-auth`: statically defined user/password for authentication.
+- `mail-auth`: validates incoming emails using SPF, DKIM, DMARC, ARC, and BIMI.
 
-By default, 3 filters exist:
+### `mail-auth`
 
-- whitelist: allow emails based on regexp or exact values
-- http-auth: proxy the authentication to an HTTP endpoint
-- http-filter: proxy the decision on the email to an HTTP endpoint
-- static-auth: staticly defined user/password for authentication
+The `mail-auth` filter validates incoming emails using a suite of authentication mechanisms: SPF (Sender Policy Framework), DKIM (DomainKeys Identified Mail), DMARC (Domain-based Message Authentication, Reporting & Conformance), ARC (Authenticated Received Chain), and BIMI (Brand Indicators for Message Identification). It helps in verifying the authenticity and integrity of emails, reducing spam and phishing attempts.
+
+Example Configuration:
+
+```json
+{
+  "type": "mail-auth",
+  "mailauth": {
+    "minBitLength": 1024,
+    "disableArc": false,
+    "disableDmarc": false,
+    "disableBimi": true,
+    "maxResolveCount": 10,
+    "maxVoidCount": 2
+  },
+  "enforceDmarc": "v=DMARC1; p=reject; rua=mailto:dmarc-reports@example.com"
+}
+```
+
+**Configuration Options:**
+
+*   `type`: (string) Must be `"mail-auth"`.
+*   `mailauth`: (object, optional) Configuration options for the underlying `mailauth` library.
+    *   `minBitLength`: (number, optional) The minimum allowed bits for RSA public keys (defaults to 1024). If a DKIM or ARC key has fewer bits, then validation is considered as failed.
+    *   `disableArc`: (boolean, optional) Disable ARC checks. Defaults to `false`.
+    *   `disableDmarc`: (boolean, optional) Disable DMARC checks. Defaults to `false`.
+    *   `disableBimi`: (boolean, optional) Disable BIMI checks. Defaults to `false`.
+    *   `maxResolveCount`: (number, optional) DNS lookup limit for SPF. RFC7208 requires this limit to be 10. Defaults to `10`.
+    *   `maxVoidCount`: (number, optional) DNS lookup limit for SPF that produce an empty result. RFC7208 requires this limit to be 2. Defaults to `2`.
+*   `enforceDmarc`: (string, optional) Enforce a specific DMARC policy. If set, all `_dmarc` records are replaced with the policy specified here. For example, `"v=DMARC1; p=reject;"`.
+
+## DKIM Key Generation
+
+This utility command helps you generate a new DKIM (DomainKeys Identified Mail) RSA key pair. It will output the public key formatted as a DNS TXT record that you need to add to your domain's DNS settings, and the private key along with example configuration snippets for use with the Nodemailer processor in this SMTP relay.
+
+### Usage
+
+You can run the command using `npx` (even without installing the package globally):
+```bash
+npx smtp-relay dkim-generate <your-domain.com> <selector>
+```
+
+-   `<your-domain.com>`: Replace this with the domain for which you are generating the DKIM key (e.g., `example.com`).
+-   `<selector>`: Replace this with a DKIM selector. This is a name you choose, often `default` or a date (e.g., `jan2024`). It must be alphanumeric.
+
+For example:
+```bash
+npx smtp-relay dkim-generate example.com default
+```
+
+### Expected Output
+
+After running the command, you will see output similar to the following:
+
+1.  **DNS TXT Record:**
+    The command will print the DNS TXT record that you need to create for your domain. It will look something like this:
+    ```text
+    <selector>._domainkey.<your-domain.com>    v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA...your...public...key...data...AQAB
+    ```
+    -   Replace `<selector>` and `<your-domain.com>` with the actual values you used.
+    -   The long string starting with `p=` is your public key. Ensure you copy the entire value for your DNS record.
+
+2.  **Configuration Snippets for `smtp-relay`:**
+    The command will also provide JSON snippets that you can adapt for your `smtp-relay` configuration, specifically for use with the `nodemailer` processor. This allows `smtp-relay` to sign outgoing emails using the generated private key.
+
+    **Option 1: Single DKIM key configuration**
+    If you are configuring a single DKIM key directly in your `nodemailer` processor options:
+    ```json
+    {
+      "outputs": [
+        {
+          "type": "nodemailer",
+          "dkim": {
+            "domainName": "<your-domain.com>",
+            "keySelector": "<selector>",
+            "privateKey": "-----BEGIN PRIVATE KEY-----\n...your...private...key...data...\n-----END PRIVATE KEY-----\n"
+          }
+          // ... other nodemailer options
+        }
+      ]
+    }
+    ```
+
+    **Option 2: Multiple DKIM keys using the `dkims` object**
+    If you prefer to manage multiple DKIM keys, potentially for different domains:
+    ```json
+    {
+      "outputs": [
+        {
+          "type": "nodemailer",
+          "dkims": {
+            "<your-domain.com>": {
+              "keySelector": "<selector>",
+              "privateKey": "-----BEGIN PRIVATE KEY-----\n...your...private...key...data...\n-----END PRIVATE KEY-----\n"
+            }
+            // ... potentially other domains
+          }
+          // ... other nodemailer options
+        }
+      ]
+    }
+    ```
+    **Important:**
+    - The `privateKey` value will be the actual multi-line PEM formatted private key. Ensure it is correctly formatted in your JSON configuration (e.g., with `\n` for newlines if storing as a single string, or loaded from a file/environment variable in production). The example output from the tool will show the private key directly.
+    - Store your private key securely. Do not commit it directly into your version control if your configuration file is tracked.
 
 ### Processors
 
 These components receive the email sent after it was accepted by the filters.
 
-There is 4 types:
-
-- aws:
-- gcp:
-- file:
-- mailer:
+There are 4 types:
+- `aws`
+- `gcp`
+- `file`
+- `mailer`
 
 ### Flows
 
-A flow is defined within the configuration, it defines the filters and the outputs to apply if the message match the filters
-
-You can have as many flow as you desire within the SMTP server
+A flow is defined within the configuration. It defines the filters and the outputs to apply if the message matches the filters. You can have as many flows as you desire within the SMTP server.
 
 ### Core
 
-Manage the coordination of different component and is in charge of capturing the mail stream
+The Core manages the coordination of different components and is in charge of capturing the mail stream.
 
 ### Common variables available for replacements
 
-_iso8601_: date and time in YYYYmmddHHiiss format
+- `_iso8601_`: date and time in `YYYYmmddHHiiss` format
+- `_timestamp_`: UNIX timestamp
+- `_id_`: Session id
 
-_timestamp_: UNIX timestamp
-
-_id_: Session id
-
-The following variables are not always available but should be within processors
-
-_from_: Email of the sender
-
-_messageId_: Message id
-
-_subject_: subject of the email
-
-_to_: list of recipient comma separated
+The following variables are not always available but should be within processors:
+- `_from_`: Email of the sender
+- `_messageId_`: Message ID
+- `_subject_`: Subject of the email
+- `_to_`: List of recipients, comma-separated
 
 ## Logs
 
-You can define log configuration with the loggers definition.
+You can define log configuration with the `loggers` definition.
 
-We currently support "CONSOLE" or "FILE"
+We currently support two types:
+- `"CONSOLE"`
+- `"FILE"`
 
-```
+```json
 "loggers": [
   {
     "level": "INFO",
@@ -207,19 +302,21 @@ We currently support "CONSOLE" or "FILE"
 ]
 ```
 
-From the library `@webda/workout`, the loglevel if not defined fallback to the `LOG_LEVEL` environment variable and then fallback again to `INFO`
+From the library `@webda/workout`, the log level, if not defined, falls back to the `LOG_LEVEL` environment variable and then falls back again to `INFO`.
 
-The `FILE` type have a size limit defined and will increment a number at the end of the filepath if needed. It has a default sizeLimit define by the library.
+The `FILE` type has a size limit defined and will increment a number at the end of the filepath if needed. It has a default `sizeLimit` defined by the library.
 
-A `format` can be defined too
+A `format` can be defined too.
 
-By default the loggers are defined as a single `CONSOLE` logger. You can disable completely by adding a `loggers: []` property
+By default, the loggers are defined as a single `CONSOLE` logger.
+[!NOTE]
+You can disable logging completely by adding a `loggers: []` property.
 
 ## CloudEvent
 
-The cloudevent representation of an email is:
+The CloudEvent representation of an email is:
 
-```
+```typescript
 /**
  * CloudEvent Data representation for smtp-relay
  */
@@ -253,19 +350,17 @@ export interface SmtpCloudEvent {
 }
 ```
 
-## Http Auth
+## HTTP Auth
 
-You can enable http auth for the smtp relay, it will then relay the username/password verification to an HTTP endpoint.
+You can enable HTTP authentication for the SMTP relay. It will then relay the username/password verification to an HTTP endpoint.
 
-Use the `http-auth` filter:
+Use the `http-auth` filter. It supports the following methods for passing credentials:
+-   **BASIC_AUTH**: Sends an `Authorization` header with Basic Auth (see [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization)).
+-   **FORM_URLENCODED**: Sends a request to the URL with `x-www-form-urlencoded` data containing the username and password.
+-   **JSON**: Sends a JSON body to the URL with the username and password.
 
-- BASIC_AUTH: It will send a `authorization` header with a Basic Auth (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization)
-- FORM_URLENCODED: It will send a request to the url with a x-form-urlencoded containing username and password
-- JSON: Sending a JSON body to the url with the username/password
-
-Configuration interface
-
-```
+**Configuration Interface:**
+```typescript
 interface HttpAuthConfiguration {
   /**
    * URL to call
@@ -330,9 +425,8 @@ interface HttpAuthConfiguration {
 }
 ```
 
-Sample:
-
-```
+**Sample:**
+```json
 {
   "type": "http-auth",
   "url": "http://localhost:16662/smtp/filter",
@@ -340,15 +434,17 @@ Sample:
 }
 ```
 
-## Http Filter
+## HTTP Filter
 
-The http filter sends the cloudevent related to the email to an http endpoint to accept or refuse the email. If the http request return a status code < 300, it means the email is accepted otherwise it is refused.
+The `http-filter` sends the CloudEvent related to the email to an HTTP endpoint to accept or refuse the email.
+- If the HTTP request returns a status code `< 300`, the email is accepted.
+- Otherwise, it is refused.
 
 See the `tests/http-filter-with-auth.json` and `test/http-filter.json` configuration examples.
 
-It can also be configured to sign request with hmac.
+It can also be configured to sign requests with HMAC.
 
-```
+```typescript
 export interface HttpFilterConfig extends HttpConfig {
   /**
    * URL to call
@@ -370,68 +466,64 @@ export interface HttpFilterConfig extends HttpConfig {
 
 ## Static Basic Auth
 
-To enable basic auth for the smtp relay you need to set the `static-auth` filter, add the AND filters operator, set the authMethods and ensure one of `secure` or `allowInsecureAuth` is set as `true` in the config example below ([Example](https://github.com/loopingz/smtp-relay/blob/main/tests/auth.json))
+To enable basic auth for the SMTP relay, you need to set the `static-auth` filter, add the `AND` filters operator, set the `authMethods`, and ensure one of `secure` or `allowInsecureAuth` is set as `true` in the configuration (see [Example](https://github.com/loopingz/smtp-relay/blob/main/tests/auth.json)).
 
-The password and username are passed either in the configuration with the field `username` and `password` or as env variables with `SMTP_USERNAME` and `SMTP_PASSWORD`
+The password and username are passed either in the configuration with the fields `username` and `password` or as environment variables `SMTP_USERNAME` and `SMTP_PASSWORD`.
 
-The password is prefixed by `${hashAlgorithm}:` where hashAlgorithm is one of `plain`, `sha256`, `sha512` or `md5` (you can get the full list of hash algorithm supported by the Node with this command `node -e "console.log(require('crypto').getHashes())`)
+The password is prefixed by `${hashAlgorithm}:` where `hashAlgorithm` is one of `plain`, `sha256`, `sha512`, or `md5`. You can get the full list of hash algorithms supported by Node with this command:
+`node -e "console.log(require('crypto').getHashes())"`
 
-`plain` can be used to not hash the password, but it is not recommended for security reason.
+[!WARNING]
+`plain` can be used to not hash the password, but it is not recommended for security reasons.
 
-A `salt` parameter can be added in the configuration with the `salt` field, or env variable `SMTP_PASSWORD_SALT`.
+A `salt` parameter can be added in the configuration with the `salt` field, or via the environment variable `SMTP_PASSWORD_SALT`.
 
 ### Encrypt your password to use
 
 You can encrypt the password to use with this command:
-
-```
+```bash
 HASH="sha256" PASSWORD="TEST" node -e 'console.log(`${process.env.HASH}:${require("crypto").createHash(process.env.HASH).update(process.env.PASSWORD).digest("hex")}`)'
 ```
 
-### Raw testing with openssl and pure SMTP protocol
+### Raw testing with OpenSSL and pure SMTP protocol
 
-For manual testing you will need to pass the username and password to the smtp-relay base64 encoded. If you use the SMTP auth method LOGIN you will encode and pass in the username and password seperately.
+For manual testing, you will need to pass the username and password to the SMTP relay, Base64 encoded. If you use the SMTP `AUTH LOGIN` method, you will encode and pass the username and password separately.
 
-Example smtp test:
+**Example SMTP test:**
 
-1. Port forward your container to your localhost.
+1.  Port forward your container to your localhost:
+    ```bash
+    docker run -p 10025:10025 loopingz/smtp-relay:latest
+    ```
+2.  Connect to `smtp-relay`:
+    ```bash
+    openssl s_client -connect localhost:10025
+    ```
+    Example SMTP conversation:
+    ```text
+    S: 220 smtp.server.com Simple Mail Transfer Service Ready
+    C: EHLO client.example.com
+    S: 250-smtp.server.com Hello client.example.com
+    S: 250-SIZE 1000000
+    S: 250 AUTH LOGIN PLAIN CRAM-MD5
+    C: AUTH LOGIN
+    S: 334 VXNlcm5hbWU6
+    C: dXNlcm5hbWU=
+    S: 334 UGFzc3dvcmQ6
+    C: cGFzc3dvcmQ=
+    S: 235 2.7.0 Authentication successful
+    ```
 
-```
- docker run -p 10025:10025 loopingz/smtp-relay:latest
-```
-
-2. Connect to smtp-relay
-
-```
-openssl s_client -connect localhost:10025
-```
-
-```
-S: 220 smtp.server.com Simple Mail Transfer Service Ready
-C: EHLO client.example.com
-S: 250-smtp.server.com Hello client.example.com
-S: 250-SIZE 1000000
-S: 250 AUTH LOGIN PLAIN CRAM-MD5
-C: AUTH LOGIN
-S: 334 VXNlcm5hbWU6
-C: adlxdkej
-S: 334 UGFzc3dvcmQ6
-C: lkujsefxlj
-S: 235 2.7.0 Authentication successful
-```
-
-Examples of ways to base64 encode your credentials:
-
-```
-base64 <<< password
+**Examples of ways to Base64 encode your credentials:**
+```bash
+base64 <<< "password"
 ```
 
-Gotcha: make sure to use a base64 encoder that encodes with Destination character set utf8 and Destination new line seperator LF(Unix), this online one does that, the MAC cml one is poop
-https://www.base64encode.org/
+[!IMPORTANT]
+Make sure to use a Base64 encoder that encodes with Destination character set UTF-8 and Destination new line separator LF (Unix). [This online one](https://www.base64encode.org/) does that. The macOS command-line `base64` tool might behave differently.
 
-Example Schema used to add basic auth to an aws-ses smtp-relay running in k8s:
-
-```
+**Example Schema for AWS SES with Basic Auth in K8s:**
+```json
 {
   "$schema": "https://raw.githubusercontent.com/loopingz/smtp-relay/main/config.schema.json",
   "flows": {
@@ -475,4 +567,5 @@ Example Schema used to add basic auth to an aws-ses smtp-relay running in k8s:
 }
 ```
 
-Note: Change your loggers level to DEBUG for help troubleshooting.
+[!NOTE]
+Change your logger level to `DEBUG` for help troubleshooting.


### PR DESCRIPTION
This commit introduces documentation for the new `dkim-generate` command-line utility in README.md.

The new "DKIM Key Generation" section explains:
- The purpose of the command (generating DKIM keys and providing setup information).
- How to run the command using `npx smtp-relay dkim-generate <domain> <selector>`.
- The expected output, including:
    - The format of the DNS TXT record.
    - Example JSON configuration snippets for integrating the generated private key with the nodemailer processor in `smtp-relay` (both single key and multiple key scenarios).
- A note on securely handling the private key.

## Changes

*please link the issues here*

Changes proposed in this pull request
