### PR TITLE
fix(server): properly cleanup all streams on error in onData

### DIFF
--- a/src/server.spec.ts
+++ b/src/server.spec.ts
@@ -299,6 +299,26 @@ class SmtpServerTest {
   }
 
   @test
+  async onDataTransformError() {
+    // Trigger transform.on('error') path by using a stream that pipes through the HeadersTransform
+    let server = new SmtpServer("./tests/whitelist-and.json");
+    const { PassThrough } = await import("node:stream");
+    const pt = new PassThrough();
+    const session = getFakeSession();
+    await new Promise<void>(resolve => {
+      server.onData(<any>pt, <any>session, (err?: any) => {
+        assert.ok(err, "Expected transform error to be propagated");
+        resolve();
+      });
+      // The pipe chain is: pt -> HeadersTransform -> writestream
+      // Access the transform via pt's pipe destination
+      const pipes = (pt as any)._readableState.pipes;
+      const transform = Array.isArray(pipes) ? pipes[0] : pipes;
+      setImmediate(() => transform.emit("error", new Error("transform error")));
+    });
+  }
+
+  @test
   async onDataStreamError() {
     // Use a real PassThrough stream and emit an error to hit stream.on('error') path
     let server = new SmtpServer("./tests/whitelist-and.json");

--- a/src/server.ts
+++ b/src/server.ts
@@ -420,12 +420,23 @@ export class SmtpServer {
     session.emailPath = SmtpServer.replaceVariables(this.config.cachePath!, { ...session });
 
     const writestream = fs.createWriteStream(session.emailPath!);
+    const transform = new HeadersTransform(this.config.mailHeaders!);
+    let callbackCalled = false;
+    const callbackOnce = (err?: any) => {
+      if (callbackCalled) return;
+      callbackCalled = true;
+      callback(err);
+    };
     // Handle write errors explicitly
     writestream.on("error", err => {
       this.logger.log("ERROR", `Error writing email to ${session.emailPath}`, err);
-      callback(err);
+      callbackOnce(err);
     });
-    stream.pipe(new HeadersTransform(this.config.mailHeaders!)).pipe(writestream);
+    transform.on("error", err => {
+      this.logger.log("ERROR", `Error transforming headers for ${session.emailPath}`, err);
+      callbackOnce(err);
+    });
+    stream.pipe(transform).pipe(writestream);
     writestream.on("finish", async () => {
       session.email = await simpleParser(fs.createReadStream(session.emailPath!));
       await this.filter("Data", session, [session]);
@@ -447,11 +458,12 @@ export class SmtpServer {
 
     stream.on("error", err => {
       try {
-        writestream.destroy(err);
+        transform.destroy();
+        writestream.destroy();
       } catch (e) {
-        this.logger.log("ERROR", `Error destroying write stream for ${session.emailPath}`, e);
+        this.logger.log("ERROR", `Error destroying streams for ${session.emailPath}`, e);
       }
-      callback(`error converting stream - ${err}`);
+      callbackOnce(`error converting stream - ${err}`);
     });
   }
 


### PR DESCRIPTION
## Summary
- Extract `HeadersTransform` into named variable for proper lifecycle management
- Add error handler on transform stream that propagates to writestream
- Destroy both transform and write streams when input stream errors (previously only writestream was destroyed)
- Prevents orphaned stream resources and file descriptor leaks

## Severity
**HIGH** — FD exhaustion under error conditions

## Test plan
- [x] All existing tests pass
- [ ] Verify no orphaned streams under stream error conditions


🤖 Generated with [Claude Code](https://claude.com/claude-code)