### PR TITLE
chore(deps): migrate to TypeScript 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "sinon": "^21.0.1",
         "ts-json-schema-generator": "^2.5.0",
         "ts-node": "^10.9.2",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.2"
       },
       "engines": {
         "node": ">= 20"
@@ -4513,6 +4513,20 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@webda/tsc-esm/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@webda/workout": {
@@ -12333,6 +12347,20 @@
       "dev": true,
       "license": "0BSD"
     },
+    "node_modules/ts-json-schema-generator/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -12516,9 +12544,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "sinon": "^21.0.1",
     "ts-json-schema-generator": "^2.5.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.2"
   },
   "auto": {
     "plugins": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,14 +5,15 @@
       "es2019",
       "DOM"
     ],
-    "module": "es2020",
+    "module": "esnext",
+    "rootDir": "./src",
     "outDir": "./lib",
     "strict": true,
     "declaration": true,
     "sourceMap": true,
     "experimentalDecorators": true,
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "skipLibCheck": true
   },
   "include": [


### PR DESCRIPTION
## Summary
- Upgrade TypeScript from 5.9.3 to 6.0.2
- Switch `moduleResolution` from deprecated `"node"` to `"bundler"`
- Update `module` from `"es2020"` to `"esnext"`
- Add explicit `rootDir: "./src"` (TS6 changed the default from inferred to `.`)

## Context
TypeScript 6.0 deprecates `moduleResolution: "node"` (node10) and changes the default `rootDir`. The `"bundler"` resolution is the best fit since the project uses `tsc-esm` for building and doesn't need the strict `.js` extension requirements of `"nodenext"`.

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [x] `npm run build` succeeds
- [x] All 56 tests pass with coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)